### PR TITLE
Wrap Postgresql user in quotation marks

### DIFF
--- a/lib/thredded_create_app/tasks/setup_database/create_database_user.sh
+++ b/lib/thredded_create_app/tasks/setup_database/create_database_user.sh
@@ -20,8 +20,8 @@ create_postgresql_user() {
     cmd="sudo -u ${PG_DAEMON_USER:-postgres} psql postgres"
   fi
   $cmd --quiet <<SQL
-CREATE ROLE $USER LOGIN PASSWORD '$PASS';
-ALTER ROLE $USER CREATEDB;
+CREATE ROLE "$USER" LOGIN PASSWORD '$PASS';
+ALTER ROLE "$USER" CREATEDB;
 SQL
 }
 


### PR DESCRIPTION
Postgresql requires quotation marks around strings with certain characters, e.g. a hyphen.

Fixes #8.