### PR TITLE
Fix: Bundler version installed in Docker image matches Gemfile

### DIFF
--- a/lib/thredded_create_app/tasks/docker/Dockerfile.erb
+++ b/lib/thredded_create_app/tasks/docker/Dockerfile.erb
@@ -9,7 +9,7 @@ RUN apk add --no-cache \
     build-base ruby-dev libc-dev linux-headers gmp-dev openssl-dev libxml2-dev \
     libxslt-dev postgresql-dev
 
-RUN gem install foreman
+RUN gem install foreman bundler
 
 ENV BUNDLE_SILENCE_ROOT_WARNING=1
 ENV BUNDLE_PATH=/bundle

--- a/lib/thredded_create_app/tasks/docker/docker-compose.yml.erb
+++ b/lib/thredded_create_app/tasks/docker/docker-compose.yml.erb
@@ -1,4 +1,4 @@
-version: "3.6"
+version: "3.7"
 networks:
   frontend:
   backend:

--- a/lib/thredded_create_app/tasks/docker/docker-compose.yml.erb
+++ b/lib/thredded_create_app/tasks/docker/docker-compose.yml.erb
@@ -1,4 +1,4 @@
-version: "3.7"
+version: "3.6"
 networks:
   frontend:
   backend:


### PR DESCRIPTION
Thanks @glebm for the quick fix in #21 to address the PR I started in #20.

After upgrading to `0.2.2` of `thredded_create_app`, I still had issues building the image with Docker.

Specifically, the `bundle install` fails during the image build because the `bundler` version required by the `Gemfile` is `2.1.4`. So this is a quick and dirty fix to ensure the latest version of `bundler` is present.